### PR TITLE
Update p1mini.yaml for 2024.6.0

### DIFF
--- a/p1mini.yaml
+++ b/p1mini.yaml
@@ -32,6 +32,7 @@ api:
     key: "${device_api_key}"
 
 ota:
+  platform: esphome
   password: "${device_password}"
 
 web_server:


### PR DESCRIPTION
Since ESPHome 2024.6.0 the ota section has a slightly different format.